### PR TITLE
Louisa TextBox-Hinweise Änderungen

### DIFF
--- a/src/main/java/de/azubiag/MassnahmenBewertung/UI/ControllerAntwortenErfassen.fxml
+++ b/src/main/java/de/azubiag/MassnahmenBewertung/UI/ControllerAntwortenErfassen.fxml
@@ -119,7 +119,7 @@
                         <Font size="20.0" />
                      </font>
                   </Hyperlink>
-                  <Button fx:id="add" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Antwort hinzufügen" GridPane.columnIndex="3" GridPane.columnSpan="3" GridPane.rowIndex="3">
+                  <Button fx:id="add" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Antwort aus der Zwischenablage einfügen" GridPane.columnIndex="3" GridPane.columnSpan="3" GridPane.rowIndex="3">
                      <font>
                         <Font size="20.0" />
                      </font>

--- a/src/main/java/de/azubiag/MassnahmenBewertung/UI/ControllerFragebogenErstellen.java
+++ b/src/main/java/de/azubiag/MassnahmenBewertung/UI/ControllerFragebogenErstellen.java
@@ -398,7 +398,7 @@ public void addVorschauButtonHandler() {
 					String webpath = getFragebogenWebPath(fragebogenOutputPfad);
 
 					boolean veroeffentlichen = AlertMethoden.entscheidungViaDialogAbfragenOnTop("Fragebogen veröffentlichen?", 
-							"Fragebogen auf " + webpath + " veröffentlichen?", true /* Fenster oben halten */);
+							"Fragebogen für Umfrage \"" +getName()+"\" veröffentlichen?", true /* Fenster oben halten */);
 										
 					if (veroeffentlichen) {
 			

--- a/src/main/java/de/azubiag/MassnahmenBewertung/UI/MainApp.java
+++ b/src/main/java/de/azubiag/MassnahmenBewertung/UI/MainApp.java
@@ -439,6 +439,8 @@ public class MainApp extends Application {
 		AlertMethoden.zeigeOKAlertWarten(AlertType.INFORMATION, "Programm wird beendet", 
 				"Das Programm wird beendet. Bitte warten.", false);
 		
+		primaryStage.hide();
+		
 		if (!listeControllerAntwortenErfassen.isEmpty()) {
 			ControllerAntwortenErfassen.serializeTabs();
 		}

--- a/src/main/java/de/azubiag/MassnahmenBewertung/UI/MainApp.java
+++ b/src/main/java/de/azubiag/MassnahmenBewertung/UI/MainApp.java
@@ -412,7 +412,7 @@ public class MainApp extends Application {
 	public void warnfensterAnwendungSchliessen(WindowEvent event) {
 
 		boolean anwendungSchließen = AlertMethoden.zeigeAlertJaNein(AlertType.WARNING, "Anwendung schließen",
-				"Ihre laufenden Umfragen und die schon eingegebenen Antworten werden gespeichert. "
+				"Ihre veröffentlichten Umfragen und die schon eingegebenen Antworten werden gespeichert. "
 						+ "Anwendung jetzt schließen ? ") ;
 
 		if (anwendungSchließen) {

--- a/src/main/java/de/azubiag/MassnahmenBewertung/tools/AlertMethoden.java
+++ b/src/main/java/de/azubiag/MassnahmenBewertung/tools/AlertMethoden.java
@@ -108,8 +108,8 @@ public class AlertMethoden {
 	 */
 	public static boolean zeigeAlertJaNein(AlertType alertType, String titel, String frage) {
 		Alert al = new Alert(alertType);
-		ButtonType jaButton = new ButtonType("ja", ButtonData.YES);
-		ButtonType neinButton = new ButtonType("nein", ButtonData.NO);
+		ButtonType jaButton = new ButtonType("Ja", ButtonData.YES);
+		ButtonType neinButton = new ButtonType("Nein", ButtonData.NO);
 		al.getButtonTypes().setAll(jaButton, neinButton);
 		al.setTitle(titel);
 		al.setHeaderText(frage);
@@ -121,9 +121,6 @@ public class AlertMethoden {
 		} 
 	}
 
-	public static final int JA = 1;
-	public static final int NEIN = 0;
-	public static final int CANCEL = -1;
 
 	public static void zeigeOKAlertTextCopyAlwaysOnTop(AlertType alertType, String title, String headerText, String copyText) {
 		GridPane gridPane = initTextArea(copyText);


### PR DESCRIPTION
** TODO LOUISA: Knopf "Antwort hinzufügen" umbenennen

Knopf "Antwort hinzufügen" umbenennen in "Antwort aus der Zwischenablage einfügen".

** TODO LOUISA: Ändern der Hinweis-Box

"Ihre laufenden Umfragen und die schon eingegebenen Antworten werden gespeichert. Anwendung jetzt schließen?"

--> "Ihre veröffentlichten Umfragen und die schon eingegebenen Antworten werden gespeichert. Anwendung jetzt schließen?"

** TODO LOUISA: Message Box ändern

"Fragebogen auf https://.... veröffentlichen" -> "Fragebogen für Umfrage .... veröffentlichen?"